### PR TITLE
As a Developer I want to be able to override the Header style

### DIFF
--- a/viktor_table_view/table_view.py
+++ b/viktor_table_view/table_view.py
@@ -81,15 +81,12 @@ class TableResult(WebResult):
 
     def update_header_style(self):
         """Updates header style if no header style is added to the styler"""
-        has_header_style = False
         if self.style.table_styles:
             for table_style in self.style.table_styles:
                 if "th" in table_style.values():
-                    has_header_style = True
-                    break
-        if not has_header_style or self.style.table_styles is None:
-            header_style = {
-                "selector": "th",
-                "props": [("text-align", "center"), ("background-color", "rgba(245, 245, 252)")],
-            }
-            self.style.set_table_styles([header_style])
+                    return
+        header_style = {
+            "selector": "th",
+            "props": [("text-align", "center"), ("background-color", "rgba(245, 245, 252)")],
+        }
+        self.style.set_table_styles([header_style])

--- a/viktor_table_view/table_view.py
+++ b/viktor_table_view/table_view.py
@@ -68,11 +68,6 @@ class TableResult(WebResult):
     def get_html(self) -> File:
         """Get the html to be displayed"""
         self.format_dataframe()
-        header_style = {
-            "selector": "th",
-            "props": [("text-align", "center"), ("background-color", "rgba(245, 245, 252)")],
-        }
-        self.style.set_table_styles([header_style])
         with open(Path(__file__).parent / "table.html.jinja", "rb") as template:
             result = render_jinja_template(
                 template, {"table_html": self.style.to_html(table_attributes='class="table table-hover"')}

--- a/viktor_table_view/table_view.py
+++ b/viktor_table_view/table_view.py
@@ -42,6 +42,7 @@ class TableResult(WebResult):
     ):
         self.dataframe = dataframe.copy(deep=True)
         self.style = style or self.dataframe.style
+        self.update_header_style()
         self.dataframe_colours = dataframe_colours
         self.n_decimals = n_decimals
         super().__init__(html=self.get_html())
@@ -77,3 +78,18 @@ class TableResult(WebResult):
                 template, {"table_html": self.style.to_html(table_attributes='class="table table-hover"')}
             )
         return result
+
+    def update_header_style(self):
+        """Updates header style if no header style is added to the styler"""
+        has_header_style = False
+        if self.style.table_styles:
+            for table_style in self.style.table_styles:
+                if "th" in table_style.values():
+                    has_header_style = True
+                    break
+        if not has_header_style or self.style.table_styles is None:
+            header_style = {
+                "selector": "th",
+                "props": [("text-align", "center"), ("background-color", "rgba(245, 245, 252)")],
+            }
+            self.style.set_table_styles([header_style])


### PR DESCRIPTION
Hi,

As a dev, I want to be able to override some aspects of the table, namely the header.
`styler = dataframe.style.set_table_styles(STYLE_OPTIONS_HEADER)`

Right now, the `get_html` function always overrides the table_styles with the header. It would be handy if the overriding only happens when there is no header style defined.